### PR TITLE
Update for Java 24, where Generational ZGC is now on by default

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,7 +66,8 @@ import Page from "../layouts/page.astro";
           JVM version
         </label>
         <select id="version" class="textbox">
-          <option value="21">21+</option>
+          <option value="24">24+</option>
+          <option value="21">21-23</option>
           <option value="17" selected>11-20</option>
           <option value="8">8</option>
         </select>

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -12,6 +12,9 @@ const result = document.getElementById("result") as HTMLElement;
 function update() {
   let flags = "";
   switch (version.value) {
+    case "24":
+      flags = "-XX:+UseZGC";
+      break;
     case "21":
       flags = "-XX:+UseZGC -XX:+ZGenerational";
       break;


### PR DESCRIPTION
Closes #1

also, for java ≥21, it no longer suggests Shenandoah. Not sure if this was intentional or not, but I kept this behaviour.